### PR TITLE
 - increase mem for seurat and archr tasks

### DIFF
--- a/src/jupyter_nb/seurat_notebook.ipynb
+++ b/src/jupyter_nb/seurat_notebook.ipynb
@@ -510,6 +510,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Set Seurat obj to NULL if number of barcodes exceed 300k - this is a temp fix until better alternative\n",
+    "\n",
+    "rna = tryCatch({\n",
+    "    log_print(\"# Check number of barcodes\")\n",
+    "    \n",
+    "        if(nrow(rna@meta.data) > 300000){\n",
+    "            stop(\"Number of barcodes exceeding 300k; terminating\")\n",
+    "        } else{\n",
+    "            log_print(\"SUCCESSFUL: Check number of barcodes\")\n",
+    "        }\n",
+    "        return(rna)\n",
+    "    },\n",
+    "    error = function(cond) {\n",
+    "        log_print(\"ERROR: Check number of barcodes\")\n",
+    "        log_print(cond)\n",
+    "        rna = NULL\n",
+    "        return(rna)\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "normalization"

--- a/tasks/share_task_archr.wdl
+++ b/tasks/share_task_archr.wdl
@@ -46,7 +46,7 @@ task archr {
         String docker_image = "swekhande/shareseq-prod:share-task-archr"
         String log_filename = "log/${prefix}.atac.archr.logfile.${genome}.txt"
 
-        Int? mem_gb = 32
+        Int? mem_gb = 128
         Int? disk_gb = 50
     }
 

--- a/tasks/share_task_seurat.wdl
+++ b/tasks/share_task_seurat.wdl
@@ -43,7 +43,7 @@ task seurat {
         String log_filename = "log/${prefix}.rna.seurat.logfile.${genome_name}.txt"
         
         String docker_image = "swekhande/shareseq-prod:share-task-seurat"
-        Int mem_gb = 16
+        Int mem_gb = 128
     }
 
     #Plot filepaths


### PR DESCRIPTION
added 'throw error' if number of barcodes exceeds 300k in Seurat task