### PR TITLE
Correction fixes

### DIFF
--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -10,26 +10,32 @@ def check_putative_barcode(barcode_str, quality_str, barcode_exact_dict, barcode
     Procedure: check exact match of barcode, then 1 mismatch, then 1bp left/right
     shift
     """
-    exact = True
-    value = barcode_exact_dict.get(barcode_str[1:9])  # check exact location first
+    correction_type = None
+    corrected = barcode_exact_dict.get(barcode_str[1:9])  # check exact location first
     quality = quality_str[1:9]
-    if value is None:
-        exact = False
-        value = barcode_mismatch_dict.get(barcode_str[1:9])  # check mismatch
-        if value is None:
-            value = barcode_exact_dict.get(barcode_str[:8])  # check 1bp shift left
+    if corrected:
+        correction_type = "E"
+    else:
+        corrected = barcode_mismatch_dict.get(barcode_str[1:9])  # check mismatch
+        if corrected:
+            correction_type = "M"
+        else:
+            corrected = barcode_exact_dict.get(barcode_str[:8])  # check 1bp shift left
             quality = quality_str[:8]
-            if value is None:
-                # check 1bp shift right
-                # round 3 is shorter so add "N" for those
+            if corrected:
+                correction_type = "L"
+            else:  # check 1bp shift right; round 3 is shorter so add "N" for those
                 if len(barcode_str) < 10:
-                    value = barcode_exact_dict.get(barcode_str[2:]+"N")
+                    corrected = barcode_mismatch_dict.get(barcode_str[2:]+"N")
                     quality = quality_str[2:]+"F"
+                    if corrected:
+                        correction_type = "R"
                 else:
-                    value = barcode_exact_dict.get(barcode_str[2:])
+                    corrected = barcode_exact_dict.get(barcode_str[2:])
                     quality = quality_str[2:]
-    return value, quality, exact
-
+                    if corrected:
+                        correction_type = "R"
+    return corrected, quality, correction_type
 
 def create_barcode_dicts(barcode_list):
     """


### PR DESCRIPTION
utils.py
1. R3 right shift was being checked against exact dictionary; now being checked against mismatch dictionary in correction function
2. Returning barcode correction type from correction function (E/M/L/R)

bam_to_raw_fastq.py
1. Adding R1 barcode correction type QC output
    - Should correction types be counted with a dict instead of with individual counters, so as to be consistent with how I count in correct_fastq.py?

correct_fastq.py
1. Adding cell barcode correction type QC output
3. Making dictionary of valid correction combinations; barcodes that do not have valid correction combinations are counted as nonmatches
    - Since we know which correction combinations we want to keep, should this dictionary be preset?
    - Should barcodes without valid correction combinations be counted in their own category instead of as nonmatches?
    - I'm counting polyG UMIs as their own category rather than appending them to the correction combination like EEEG, EEEU, etc.--is this ok?