### PR TITLE
Html fix

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -8,6 +8,7 @@ workflows:
              - rc-v2.0.0
              - dev
              - chromap-v2
+             - html-fix
          tags:
              - /.*/
 

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -8,7 +8,6 @@ workflows:
              - rc-v2.0.0
              - dev
              - chromap-v2
-             - html-fix
          tags:
              - /.*/
 

--- a/tasks/task_html_report.wdl
+++ b/tasks/task_html_report.wdl
@@ -61,7 +61,7 @@ task html_report {
         
         # This can be uncommented once we get the rna_metrics file sorted out
         #PYTHONIOENCODING=utf-8 python3 /software/write_html.py ~{output_file} image_list.txt log_list.txt ~{output_csv_file} ~{atac_metrics} ~{rna_metrics}
-        PYTHONIOENCODING=utf-8 python3 /software/write_html.py ~{output_file} image_list.txt log_list.txt ~{output_csv_file} ~{atac_metrics} summary_stats.csv
+        PYTHONIOENCODING=utf-8 python3 /software/write_html.py ~{output_file} image_list.txt log_list.txt ~{output_csv_file} summary_stats.csv ~{if defined(atac_metrics) then '--summary_stats_txt ~{atac_metrics}' else ''}
 
         # TODO: this needs to be fix.
         echo 'PKR,~{prefix}' | cat - ~{output_csv_file} > temp && mv temp ~{output_csv_file} 

--- a/tasks/task_html_report.wdl
+++ b/tasks/task_html_report.wdl
@@ -51,17 +51,23 @@ task html_report {
         echo "~{sep="\n" valid_image_files}" > image_list.txt
         echo "~{sep="\n" valid_log_files}" > log_list.txt
         
-        echo "rna_total_reads,"~{rna_total_reads} > summary_stats.csv
-        echo "rna_aligned_uniquely," ~{rna_aligned_uniquely} >> summary_stats.csv
-        echo "rna_aligned_multimap," ~{rna_aligned_multimap} >> summary_stats.csv
-        echo "rna_unaligned," ~{rna_unaligned} >> summary_stats.csv
-        echo "rna_feature_reads," ~{rna_feature_reads} >> summary_stats.csv
-        echo "rna_duplicate_reads," ~{rna_duplicate_reads} >> summary_stats.csv
-        echo "rna_frig," ~{rna_frig} >> summary_stats.csv
+        echo "rna_total_reads,"~{rna_total_reads} > rna_metrics.csv
+        echo "rna_aligned_uniquely," ~{rna_aligned_uniquely} >> rna_metrics.csv
+        echo "rna_aligned_multimap," ~{rna_aligned_multimap} >> rna_metrics.csv
+        echo "rna_unaligned," ~{rna_unaligned} >> rna_metrics.csv
+        echo "rna_feature_reads," ~{rna_feature_reads} >> rna_metrics.csv
+        echo "rna_duplicate_reads," ~{rna_duplicate_reads} >> rna_metrics.csv
+        echo "rna_frig," ~{rna_frig} >> rna_metrics.csv
         
         # This can be uncommented once we get the rna_metrics file sorted out
         #PYTHONIOENCODING=utf-8 python3 /software/write_html.py ~{output_file} image_list.txt log_list.txt ~{output_csv_file} ~{atac_metrics} ~{rna_metrics}
-        PYTHONIOENCODING=utf-8 python3 /software/write_html.py ~{output_file} image_list.txt log_list.txt ~{output_csv_file} summary_stats.csv ~{if defined(atac_metrics) then '--summary_stats_txt ~{atac_metrics}' else ''}
+        PYTHONIOENCODING=utf-8 python3 /software/write_html.py \
+        ~{output_file} \
+        image_list.txt \
+        log_list.txt \
+        ~{output_csv_file} \
+        --rna_metrics rna_metrics.csv \
+        ~{if defined(atac_metrics) then '--atac_metrics ~{atac_metrics}' else ''}
 
         # TODO: this needs to be fix.
         echo 'PKR,~{prefix}' | cat - ~{output_csv_file} > temp && mv temp ~{output_csv_file} 

--- a/tasks/task_html_report.wdl
+++ b/tasks/task_html_report.wdl
@@ -51,13 +51,13 @@ task html_report {
         echo "~{sep="\n" valid_image_files}" > image_list.txt
         echo "~{sep="\n" valid_log_files}" > log_list.txt
         
-        echo "rna_total_reads,"~{rna_total_reads} > rna_metrics.csv
-        echo "rna_aligned_uniquely," ~{rna_aligned_uniquely} >> rna_metrics.csv
-        echo "rna_aligned_multimap," ~{rna_aligned_multimap} >> rna_metrics.csv
-        echo "rna_unaligned," ~{rna_unaligned} >> rna_metrics.csv
-        echo "rna_feature_reads," ~{rna_feature_reads} >> rna_metrics.csv
-        echo "rna_duplicate_reads," ~{rna_duplicate_reads} >> rna_metrics.csv
-        echo "rna_frig," ~{rna_frig} >> rna_metrics.csv
+        echo "rna_total_reads," ~{if defined(rna_total_reads) then rna_total_reads else 0} > rna_metrics.csv
+        echo "rna_aligned_uniquely," ~{if defined(rna_aligned_uniquely) then rna_aligned_uniquely else 0} >> rna_metrics.csv
+        echo "rna_aligned_multimap," ~{if defined(rna_aligned_multimap) then rna_aligned_multimap else 0} >> rna_metrics.csv
+        echo "rna_unaligned," ~{if defined(rna_unaligned) then rna_unaligned else 0} >> rna_metrics.csv
+        echo "rna_feature_reads," ~{if defined(rna_feature_reads) then rna_feature_reads else 0} >> rna_metrics.csv
+        echo "rna_duplicate_reads," ~{if defined(rna_duplicate_reads) then rna_duplicate_reads else 0} >> rna_metrics.csv
+        echo "rna_frig," ~{if defined(rna_frig) then rna_frig else 0} >> rna_metrics.csv
         
         # This can be uncommented once we get the rna_metrics file sorted out
         #PYTHONIOENCODING=utf-8 python3 /software/write_html.py ~{output_file} image_list.txt log_list.txt ~{output_csv_file} ~{atac_metrics} ~{rna_metrics}


### PR DESCRIPTION
Overview: I've modified the write_html.py script to optionally take an RNA metrics file and an ATAC metrics file.

Note: if the RNA stats inputted to the task are empty, i.e. in the case of only ATAC, I write the RNA stats into the RNA metrics file as 0s. This is because the script tries to convert the stat value to a float, and fails if the stat is an empty string. So, the RNA stats are all just printed out as 0 in the html report. Ideally, if it was only ATAC, the RNA stats would not be printed at all. Suggestions for improving this are welcome; I don't love how I'm doing it right now.