### PR TITLE
Update correction v2

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -9,6 +9,7 @@ workflows:
              - dev
              - chromap-v2
              - dev-snapatac
+             - update-correction-v2
          tags:
              - /.*/
 

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -9,7 +9,6 @@ workflows:
              - dev
              - chromap-v2
              - dev-snapatac
-             - update-correction-v2
          tags:
              - /.*/
 

--- a/combinomics.wdl
+++ b/combinomics.wdl
@@ -192,9 +192,6 @@ workflow combinomics {
         Array[File]? atac_read2_processed = atac.atac_read2_processed
         Array[File]? atac_barcode_processed = atac.atac_barcode_processed
 
-        Array[File]? rna_read1_processed = rna.rna_read1_processed
-        Array[File]? rna_read2_processed = rna.rna_read2_processed
-
         # RNA outputs
         File? rna_final_bam = rna.task_starsolo_output_bam
         File? rna_starsolo_raw_tar = rna.task_starsolo_raw_tar

--- a/combinomics.wdl
+++ b/combinomics.wdl
@@ -77,8 +77,8 @@ workflow combinomics {
 
     Map[String, File] whitelists = read_map(whitelists_tsv)
     File? whitelist_ = if chemistry=='10x_multiome' then whitelist else select_first([whitelist, whitelists[chemistry]])
-    File? whitelist_rna_ = if chemistry=="10x_multiome" then select_first([whitelist_rna, whitelists["${chemistry}_rna"]]) else whitelist_rna
-    File? whitelist_atac_ = if chemistry=="10x_multiome" then select_first([whitelist_atac, whitelists["${chemistry}_atac"]]) else whitelist_atac
+    File? whitelist_rna_ = if (chemistry=="10x_multiome" || chemistry=="shareseq") then select_first([whitelist_rna, whitelists["${chemistry}_rna"]]) else whitelist_rna
+    File? whitelist_atac_ = if (chemistry=="10x_multiome" || chemistry=="shareseq") then select_first([whitelist_atac, whitelists["${chemistry}_atac"]]) else whitelist_atac
 
     if ( chemistry != "shareseq" && process_atac) {
         scatter (idx in range(length(read1_atac))) {

--- a/combinomics.wdl
+++ b/combinomics.wdl
@@ -76,7 +76,7 @@ workflow combinomics {
     Boolean process_rna = if length(read1_rna)>0 then true else false
 
     Map[String, File] whitelists = read_map(whitelists_tsv)
-    File? whitelist_ = if chemistry=='10x_multiome' then whitelist else select_first([whitelist, whitelists[chemistry]])
+    File? whitelist_ = if (chemistry=="10x_multiome" || chemistry=="shareseq") then whitelist else select_first([whitelist, whitelists[chemistry]])
     File? whitelist_rna_ = if (chemistry=="10x_multiome" || chemistry=="shareseq") then select_first([whitelist_rna, whitelists["${chemistry}_rna"]]) else whitelist_rna
     File? whitelist_atac_ = if (chemistry=="10x_multiome" || chemistry=="shareseq") then select_first([whitelist_atac, whitelists["${chemistry}_atac"]]) else whitelist_atac
 

--- a/dockerfiles/task_generate_h5.dockerfile
+++ b/dockerfiles/task_generate_h5.dockerfile
@@ -16,7 +16,7 @@ LABEL software.task="generate_h5"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install python packages
-RUN python3 -m pip install --no-cache-dir h5py scipy
+RUN python3 -m pip install --no-cache-dir h5py scipy==1.10.0
 
 # Create and setup new user
 ENV USER=shareseq

--- a/src/python/bam_to_raw_fastq.py
+++ b/src/python/bam_to_raw_fastq.py
@@ -112,16 +112,16 @@ def write_fastqs(bam_file,
                 # get R1 barcode sequence
                 r1_barcode_raw = barcode_tag[15:23]
                 # get error-corrected R1 barcode
-                r1_barcode_corrected, is_exact = check_putative_barcode(r1_barcode_raw,
-                                                                        r1_barcode_exact_dict,
-                                                                        r1_barcode_mismatch_dict)
+                r1_barcode_corrected, correction_type = check_putative_barcode(r1_barcode_raw,
+                                                                               r1_barcode_exact_dict,
+                                                                               r1_barcode_mismatch_dict)
 
                 if r1_barcode_corrected:
                     # write reads to appropriate FASTQ files by checking which R1 barcode subset the corrected R1 barcode belongs to
                     write_read(read_1_pointers[r1_barcode_subset_dict[r1_barcode_corrected]], read_1)
                     write_read(read_2_pointers[r1_barcode_subset_dict[r1_barcode_corrected]], read_2)
 
-                    if is_exact:
+                    if correction_type == "E":
                         exact_match += 1
                     else:
                         mismatch += 1

--- a/src/python/correct_fastq.py
+++ b/src/python/correct_fastq.py
@@ -129,15 +129,14 @@ def process_fastqs(input_read1_fastq_file,
             # last 99bp of read 2 contains barcode sequences
             read_2_barcode_sequence = sequence2[-99:]
             read_2_barcode_quality = quality2[-99:]
-            # extract 10bp sequence containing R1 barcode, 10bp sequence containing R2 barcode,
-            # 9bp sequence containing R3 barcode, and corresponding quality strings
-            r1_window, r2_window, r3_window = read_2_barcode_sequence[15:23], read_2_barcode_sequence[53:61], read_2_barcode_sequence[91:99]
+            # extract barcode rounds and corresponding quality strings
+            r1_str, r2_str, r3_str = read_2_barcode_sequence[15:23], read_2_barcode_sequence[53:61], read_2_barcode_sequence[91:99]
             q1, q2, q3 = read_2_barcode_quality[15:23], read_2_barcode_quality[53:61], read_2_barcode_quality[91:99]
             # get corrected barcodes and correction type
             r1 = r2 = r3 = None
-            r1, c1 = check_putative_barcode(r1_window, r1_barcode_exact_dict, r1_barcode_mismatch_dict)
-            r2, c2 = check_putative_barcode(r2_window, r2_barcode_exact_dict, r2_barcode_mismatch_dict)
-            r3, c3 = check_putative_barcode(r3_window, r3_barcode_exact_dict, r3_barcode_mismatch_dict)
+            r1, c1 = check_putative_barcode(r1_str, r1_barcode_exact_dict, r1_barcode_mismatch_dict)
+            r2, c2 = check_putative_barcode(r2_str, r2_barcode_exact_dict, r2_barcode_mismatch_dict)
+            r3, c3 = check_putative_barcode(r3_str, r3_barcode_exact_dict, r3_barcode_mismatch_dict)
 
             # if corrected barcodes found and correction type is valid,
             # write to both read 1 and read 2 FASTQ files

--- a/src/python/correct_fastq.py
+++ b/src/python/correct_fastq.py
@@ -131,13 +131,13 @@ def process_fastqs(input_read1_fastq_file,
             read_2_barcode_quality = quality2[-99:]
             # extract 10bp sequence containing R1 barcode, 10bp sequence containing R2 barcode,
             # 9bp sequence containing R3 barcode, and corresponding quality strings
-            r1_str, r2_str, r3_str = read_2_barcode_sequence[15:23], read_2_barcode_sequence[53:61], read_2_barcode_sequence[91:99]
-            q1_str, q2_str, q3_str = read_2_barcode_quality[15:23], read_2_barcode_quality[53:61], read_2_barcode_quality[91:99]
-            # get corrected barcodes
+            r1_window, r2_window, r3_window = read_2_barcode_sequence[15:23], read_2_barcode_sequence[53:61], read_2_barcode_sequence[91:99]
+            q1, q2, q3 = read_2_barcode_quality[15:23], read_2_barcode_quality[53:61], read_2_barcode_quality[91:99]
+            # get corrected barcodes and correction type
             r1 = r2 = r3 = None
-            r1, c1 = check_putative_barcode(r1_str, r1_barcode_exact_dict, r1_barcode_mismatch_dict)
-            r2, c2 = check_putative_barcode(r2_str, r2_barcode_exact_dict, r2_barcode_mismatch_dict)
-            r3, c3 = check_putative_barcode(r3_str, r3_barcode_exact_dict, r3_barcode_mismatch_dict)
+            r1, c1 = check_putative_barcode(r1_window, r1_barcode_exact_dict, r1_barcode_mismatch_dict)
+            r2, c2 = check_putative_barcode(r2_window, r2_barcode_exact_dict, r2_barcode_mismatch_dict)
+            r3, c3 = check_putative_barcode(r3_window, r3_barcode_exact_dict, r3_barcode_mismatch_dict)
 
             # if corrected barcodes found and correction type is valid,
             # write to both read 1 and read 2 FASTQ files
@@ -154,10 +154,10 @@ def process_fastqs(input_read1_fastq_file,
                     # or R1R2R3UMIread2 if paired-end RNA
                     if paired_rna:
                         corrected_sequence2 = r1 + r2 + r3 + sequence2[:-99]
-                        corrected_quality2 = q1_str + q2_str + q3_str + quality2[:-99]
+                        corrected_quality2 = q1 + q2 + q3 + quality2[:-99]
                     else:
                         corrected_sequence2 = r1 + r2 + r3 + sequence2[:10]
-                        corrected_quality2 = q1_str + q2_str + q3_str + quality2[:10]
+                        corrected_quality2 = q1 + q2 + q3 + quality2[:10]
                     corrected_read2 = f"{corrected_header}\n{corrected_sequence2}\n+\n{corrected_quality2}\n"
                     buffer2.append(corrected_read2)
                     buffer_counter += 1
@@ -177,7 +177,7 @@ def process_fastqs(input_read1_fastq_file,
                     buffer2.append(corrected_read2)
                     # add corrected barcode to buffer3 AKA fastq barcode
                     corrected_sequence3 = r1 + r2 + r3
-                    corrected_quality3 = q1_str + q2_str + q3_str
+                    corrected_quality3 = q1 + q2 + q3
                     corrected_read3 = f"{corrected_header}\n{corrected_sequence3}\n+\n{corrected_quality3}\n"
                     buffer3.append(corrected_read3)
                     buffer_counter += 1

--- a/src/python/rna_barcode_metadata.py
+++ b/src/python/rna_barcode_metadata.py
@@ -6,7 +6,6 @@ total reads, duplicate reads, UMIs, genes, and percent mitochondrial reads for e
 """
 
 import argparse
-import logging
 import numpy as np
 import pysam
 from collections import defaultdict
@@ -45,6 +44,9 @@ def get_metrics(bam, barcode_tag="CB", subpool=None):
         barcode = read.get_tag(barcode_tag)
         if barcode == "-":
             continue
+
+        # remove underscores from barcode
+        barcode = barcode.replace("_", "")
             
         # get UMI; skip read if not present
         umi = read.get_tag("UB")

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -33,7 +33,7 @@ def create_barcode_dicts(barcode_list):
     for barcode in barcode_list:
         barcode_exact_dict[barcode] = barcode  # exact match
         for i, base in enumerate(barcode):
-            for x in 'ACGT':
+            for x in 'ACGTN':
                 if base != x:
                     # add mismatch possibilities at pos i
                     mismatch = barcode[:i] + x + barcode[i + 1:]

--- a/tasks/task_log_rna.wdl
+++ b/tasks/task_log_rna.wdl
@@ -16,44 +16,126 @@ task log_rna {
         # This function takes as input the necessary log files and extracts
         # the quality metrics
         File alignment_log
-        File dups_log
+        File barcode_statistics
+        File summary_csv
+        File qc_rna_statistics
         String? prefix = "sample"
     }
 
     command <<<
-        total_reads=$(awk -F"|" '$1~/input reads/{print $2}' ~{alignment_log} | tr -d "\t")
-        aligned_uniquely=$(awk -F"|" '$1~/Uniquely mapped reads number/{print $2}' ~{alignment_log} | tr -d "\t")
-        aligned_multimap=$(awk -F"|" '$1~/Number of reads mapped to multiple loci/{print $2}' ~{alignment_log} | tr -d "\t")
-        aligned=$(($aligned_uniquely + $aligned_multimap))
-        unaligned=$(($total_reads - $aligned))
+        # get STARsolo alignment log statistics
+        input_reads=$(awk -F "|" '$1~/input reads/{print $2}' ~{alignment_log} | tr -d "\t")
+        aligned_uniquely=$(awk -F "|" '$1~/Uniquely mapped reads number/{print $2}' ~{alignment_log} | tr -d "\t")
+        aligned_multimap=$(awk -F "|" '$1~/Number of reads mapped to multiple loci/{print $2}' ~{alignment_log} | tr -d "\t")
+        aligned_reads=$(($aligned_uniquely + $aligned_multimap))
+        unaligned_reads=$(($input_reads - $aligned_reads))
+
+        echo "$input_reads" > input_reads.txt
+        echo "$aligned_uniquely" > aligned_uniquely.txt
+        echo "$aligned_multimap" > aligned_multimap.txt
+        echo "$aligned_reads" > aligned_reads.txt
+        echo "$unaligned_reads" > unaligned_reads.txt
+
+        # get STARsolo barcode statistics
+        awk -F " " '$1~/noUMIhomopolymer/{print $2}' ~{barcode_statistics} > homopolymer_umis.txt
+        awk -F " " '$1~/noNoWLmatch/{print $2}' ~{barcode_statistics} > nonmatch_barcodes.txt
+        awk -F " " '$1~/yesWLmatchExact/{print $2}' ~{barcode_statistics} > exact_match_barcodes.txt
+        awk -F " " '$1~/yesOneWLmatchWithMM/{print $2}' ~{barcode_statistics} > mismatch_barcodes.txt
+
+        # get STARsolo summary statistics
+        awk -F "," '$1~/Reads With Valid Barcodes/{printf "%.2f\n", $2}' ~{summary_csv} > frac_valid_barcodes.txt
+        awk -F "," '$1~/Sequencing Saturation/{printf "%.2f\n", $2}' ~{summary_csv} > sequencing_saturation.txt
+        awk -F "," '$1~/Q30 Bases in CB\+UMI/{printf "%.2f\n", $2}' ~{summary_csv} > frac_q30_bases_in_cb_umi.txt
+        awk -F "," '$1~/Q30 Bases in RNA read/{printf "%.2f\n", $2}' ~{summary_csv} > frac_q30_bases_in_read.txt
+        awk -F "," '$1~/Reads Mapped to GeneFull: Unique\+Multiple GeneFull/{printf "%.2f\n", $2}' ~{summary_csv} > starsolo_frig.txt
+        awk -F "," '$1~/Estimated Number of Cells/{print $2}' ~{summary_csv} > estimated_cells.txt
+        awk -F "," '$1~/Fraction of Unique Reads in Cells/{printf "%.2f\n", $2}' ~{summary_csv} > frac_unique_reads_in_cells.txt
+        awk -F "," '$1~/Median Reads per Cell/{print $2}' ~{summary_csv} > median_reads_per_cell.txt
+        awk -F "," '$1~/Median UMI per Cell/{print $2}' ~{summary_csv} > median_umis_per_cell.txt
+        awk -F "," '$1~/Median GeneFull per Cell/{print $2}' ~{summary_csv} > median_genes_per_cell.txt
+        awk -F "," '$1~/Total GeneFull Detected/{print $2}' ~{summary_csv} > genes.txt
+
+        # get qc_rna statistics
+        awk -F "," '$1~/RNA_unique_reads_mapped_to_genes/{print $2}' ~{qc_rna_statistics} > unique_reads_mapped_to_genes.txt
+        awk -F "," '$1~/RNA_FRIG/{print $2}' ~{qc_rna_statistics} > qc_rna_frig.txt
+        awk -F "," '$1~/RNA_duplicate_reads/{print $2}' ~{qc_rna_statistics} > duplicate_reads.txt
+        awk -F "," '$1~/RNA_percent_duplicates/{print $2}' ~{qc_rna_statistics} > percent_duplicates.txt
+        awk -F "," '$1~/RNA_percent_mitochondrial/{print $2}' ~{qc_rna_statistics} > percent_mitochondrial.txt
         
-        echo "RNA_input_reads,$total_reads" > ~{prefix}_rna_qc_metrics.csv
-        echo "RNA_aligned_reads,$aligned" >> ~{prefix}_rna_qc_metrics.csv
+        # write statistics into metrics file to be used in HTML report
+        echo "RNA_input_reads,$input_reads" > ~{prefix}_rna_qc_metrics.csv
+        echo "RNA_aligned_reads,$aligned_reads" >> ~{prefix}_rna_qc_metrics.csv
         echo "RNA_uniquely_aligned_reads,$aligned_uniquely" >> ~{prefix}_rna_qc_metrics.csv
         echo "RNA_multimapped_reads,$aligned_multimap" >> ~{prefix}_rna_qc_metrics.csv
-        echo "RNA_unaligned_reads,$unaligned" >> ~{prefix}_rna_qc_metrics.csv
+        echo "RNA_unaligned_reads,$unaligned_reads" >> ~{prefix}_rna_qc_metrics.csv
 
-        cat ~{dups_log} >> ~{prefix}_rna_qc_metrics.csv
+        cat ~{qc_rna_statistics} >> ~{prefix}_rna_qc_metrics.csv
     >>>
 
     output {
-        File rna_qc_metrics = "~{prefix}_rna_qc_metrics.csv"
+        File rna_qc_metrics = "${prefix}_rna_qc_metrics.csv"
+
+        # STARsolo alignment log statistics
+        Int rna_input_reads = read_int("input_reads.txt")
+        Int rna_aligned_reads = read_int("aligned_reads.txt")
+        Int rna_aligned_uniquely = read_int("aligned_uniquely.txt")
+        Int rna_aligned_multimap = read_int("aligned_multimap.txt")
+        Int rna_unaligned_reads = read_int("unaligned_reads.txt")
+
+        # STARsolo barcode statistics
+        Int rna_homopolymer_umis = read_int("homopolymer_umis.txt")
+        Int rna_nonmatch_barcodes = read_int("nonmatch_barcodes.txt")
+        Int rna_exact_match_barcodes = read_int("exact_match_barcodes.txt")
+        Int rna_mismatch_barcodes = read_int("mismatch_barcodes.txt")
+
+        # STARsolo summary statistics
+        Float rna_frac_valid_barcodes = read_float("frac_valid_barcodes.txt")
+        Float rna_sequencing_saturation = read_float("sequencing_saturation.txt")
+        Float rna_frac_q30_bases_in_cb_umi = read_float("frac_q30_bases_in_cb_umi.txt")
+        Float rna_frac_q30_bases_in_read = read_float("frac_q30_bases_in_read.txt")
+        Float rna_starsolo_frig = read_float("starsolo_frig.txt")
+        Int rna_estimated_cells = read_int("estimated_cells.txt")
+        Float rna_frac_unique_reads_in_cells = read_float("frac_unique_reads_in_cells.txt")
+        Int rna_median_reads_per_cell = read_int("median_reads_per_cell.txt")
+        Int rna_median_umis_per_cell = read_int("median_umis_per_cell.txt")
+        Int rna_median_genes_per_cell = read_int("median_genes_per_cell.txt")
+        Int rna_genes = read_int("genes.txt")
+
+        # qc_rna statistics
+        Int rna_unique_reads_mapped_to_genes = read_int("unique_reads_mapped_to_genes.txt")
+        Float rna_qc_rna_frig = read_float("qc_rna_frig.txt")
+        Int rna_duplicate_reads = read_int("duplicate_reads.txt")
+        Float rna_percent_duplicates = read_float("percent_duplicates.txt")
+        Float rna_percent_mitochondrial = read_float("percent_mitochondrial.txt")
     }
 
     runtime {
         docker: 'ubuntu:latest'
     }
+
     parameter_meta {
         alignment_log: {
             description: 'RNA alignment log file',
-	        help: 'Log file from RNA alignment step.',
+	        help: 'STARsolo log file from RNA alignment step.',
             example: 'SS-PKR-30-96-ENTIRE-PLATE.rna.align.hg38.Log.out'
         }
 
-        dups_log: {
-            description: 'Group UMI dups log file',
-            help: 'Log file from group UMI task',
-            example: 'SS-PKR-30-96-ENTIRE-PLATE.rm_dup_barcode.log.txt'
+        barcode_statistics: {
+            description: 'RNA alignment barcode statistics file',
+            help: 'STARsolo barcode statistics file from RNA alignment step.',
+            example: 'SS-PKR-30-96-ENTIRE-PLATE.Barcodes.stats'
+        }
+
+        summary_csv: {
+            description: 'RNA alignment summary csv file',
+            help: 'STARsolo summary csv file from RNA alignment step.',
+            example: 'SS-PKR-30-96-ENTIRE-PLATE.Summary.csv'
+        }
+
+        qc_rna_statistics: {
+            description: 'RNA QC statistics file',
+            help: 'Statistics file outputted by qc_rna task',
+            example: 'SS-PKR-30-96-ENTIRE-PLATE.qc.rna.hg38.qc.statistics.txt'
         }
     }
 }

--- a/tasks/task_qc_rna.wdl
+++ b/tasks/task_qc_rna.wdl
@@ -44,7 +44,7 @@ task qc_rna {
     String bai = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.bam.bai"
     String barcode_metadata = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.barcode.metadata.tsv"
     String mapped_to_gene = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.reads.mapped.to.genes.txt"
-    String duplicates_log = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.duplicates.log.txt"
+    String qc_statistics = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.qc.statistics.txt"
     String umi_barcode_rank_plot = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.umi.barcode.rank.plot.png"
     String gene_barcode_rank_plot = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.gene.barcode.rank.plot.png"
     String gene_umi_scatter_plot = "~{default="share-seq" prefix}.qc.rna.~{genome_name}.gene.umi.scatter.plot.png"
@@ -77,8 +77,8 @@ task qc_rna {
         join -t $'\t' -e 0 -j1 <(cat tmp_metadata.tsv | (sed -u 1q;sort -k1,1)) barcode_count_statistics_dedup.tsv | \
         awk -v OFS="\t" 'NR==1{print $0,"FRIG"}NR>1{printf "%s\t%4.2f\n",$0,$9/$2}' > ~{barcode_metadata}
 
-        # Write aggregate statistics into duplicates log
-        awk -v OFS="," 'NR>1{total+=$2; mito+=$4; unique+=$9} END {print "RNA_unique_reads_mapped_to_genes", unique; printf "RNA_FRIG,%.2f\n",unique/total; print "RNA_duplicate_reads", total-unique; printf "RNA_percent_duplicates,%.1f\n", (total-unique)/total*100; printf "RNA_percent_mitochondrial,%.1f\n", mito/total*100}' ~{barcode_metadata} > ~{duplicates_log}
+        # Write aggregate statistics into QC statistics file
+        awk -v OFS="," 'NR>1{total+=$2; mito+=$4; unique+=$9} END {print "RNA_unique_reads_mapped_to_genes", unique; printf "RNA_FRIG,%.2f\n",unique/total; print "RNA_duplicate_reads", total-unique; printf "RNA_percent_duplicates,%.1f\n", (total-unique)/total*100; printf "RNA_percent_mitochondrial,%.1f\n", mito/total*100}' ~{barcode_metadata} > ~{qc_statistics}
 
         # Make QC plots
         Rscript $(which rna_qc_plots.R) ~{barcode_metadata} ~{umi_min_cutoff} ~{gene_min_cutoff} ~{hist_min_umi} ~{hist_max_umi} ~{umi_barcode_rank_plot} ~{gene_barcode_rank_plot} ~{gene_umi_scatter_plot} ~{umi_histogram_plot}
@@ -86,7 +86,7 @@ task qc_rna {
 
     output {
         File rna_barcode_metadata = "~{barcode_metadata}"
-        File rna_duplicates_log = "~{duplicates_log}"
+        File rna_qc_statistics = "~{qc_statistics}"
         File? rna_umi_barcode_rank_plot = "~{umi_barcode_rank_plot}"
         File? rna_gene_barcode_rank_plot = "~{gene_barcode_rank_plot}"
         File? rna_gene_umi_scatter_plot = "~{gene_umi_scatter_plot}"


### PR DESCRIPTION
- Removing shifting from bam_to_raw_fastq, correct_fastq, utils
- Removing correct_fastq task for RNA workflow, performing correction using STARsolo
- Using separate RNA and ATAC whitelists for SHARE (see updated whitelist tsv here: "gs://fc-secure-4662fb7b-c22e-413c-9065-08458b4c3fc2/whitelists.tsv"; I have not yet updated the version in the broad-buenrostro-genome-annotations bucket)
- Adding extra RNA stats
- Setting fixed scipy version in generate_h5 dockerfile; updated version was causing matrix creation to fail